### PR TITLE
PAT-494 PR validator also checks titles

### DIFF
--- a/.github/workflows/pr-checker.yml
+++ b/.github/workflows/pr-checker.yml
@@ -3,7 +3,7 @@ name: PR checker
 on:
   pull_request:
     branches: [master, main]
-    types: [opened, edited, synchronize]
+    types: [opened, edited, labeled, unlabeled, synchronize]
 
 jobs:
   check-for-cc:

--- a/.github/workflows/pr-checker.yml
+++ b/.github/workflows/pr-checker.yml
@@ -20,6 +20,6 @@ jobs:
         uses: transferwise/actions-pr-checker@v0.0.3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PULL_REQUEST_NOT_CONTAINS_PATTERN: '.*Why is this PR necessary?.*'
+          PR_NOT_CONTAINS_PATTERN: '.*Why is this PR necessary?.*'
           SUCCESS_EMOJI: '+1'
-          PULL_REQUEST_COMMENT: 'Please check description. \nShould be meaningful and not empty.'
+          PR_COMMENT: 'Please check description. \nShould be meaningful and not empty.'

--- a/.github/workflows/pr-checker.yml
+++ b/.github/workflows/pr-checker.yml
@@ -20,6 +20,6 @@ jobs:
         uses: transferwise/actions-pr-checker@v1.0.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PULL_REQUEST_NOT_CONTAINS_PATTERN: '.*Why is this PR necessary?.*'
+          PULL_REQUEST_NOT_CONTAINS_PATTERN: 'Why is this PR necessary?'
           SUCCESS_EMOJI: '+1'
           PULL_REQUEST_COMMENT: 'Please check description. \nShould be meaningful and not empty.'

--- a/.github/workflows/pr-checker.yml
+++ b/.github/workflows/pr-checker.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   check-for-cc:
 
-    name: Check description
+    name: Check PR by stable version
     runs-on: [ubuntu-latest]
     steps:
       - name: Run actions/checkout
@@ -17,9 +17,9 @@ jobs:
           fetch-depth: 1
 
       - name: Run check
-        uses: transferwise/actions-pr-checker@v0.0.3
+        uses: transferwise/actions-pr-checker@v1.0.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_NOT_CONTAINS_PATTERN: '.*Why is this PR necessary?.*'
+          PULL_REQUEST_NOT_CONTAINS_PATTERN: '.*Why is this PR necessary?.*'
           SUCCESS_EMOJI: '+1'
-          PR_COMMENT: 'Please check description. \nShould be meaningful and not empty.'
+          PULL_REQUEST_COMMENT: 'Please check description. \nShould be meaningful and not empty.'

--- a/.github/workflows/pr-self-checker.yml
+++ b/.github/workflows/pr-self-checker.yml
@@ -21,7 +21,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_CONTAINS_PATTERN: '.{20,}'
-          PR_NOT_CONTAINS_PATTERN: '.*Why is this PR necessary?.*'
+          PR_NOT_CONTAINS_PATTERN: 'Why is this PR necessary?'
 #          PR_COMMENT: 'Please check description. \nShould be meaningful and not empty.'
 
       - name: Unit tests

--- a/.github/workflows/pr-self-checker.yml
+++ b/.github/workflows/pr-self-checker.yml
@@ -3,7 +3,7 @@ name: PR self checker
 on:
   pull_request:
     branches: [master, main]
-    types: [opened, edited, synchronize]
+    types: [opened, edited, labeled, unlabeled, synchronize]
 
 jobs:
   self-check:

--- a/.github/workflows/pr-self-checker.yml
+++ b/.github/workflows/pr-self-checker.yml
@@ -20,9 +20,9 @@ jobs:
         run: ./pr-checker.sh
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PULL_REQUEST_CONTAINS_PATTERN: '.{20,}'
-          PULL_REQUEST_NOT_CONTAINS_PATTERN: '.*Why is this PR necessary?.*'
-#          PULL_REQUEST_COMMENT: 'Please check description. \nShould be meaningful and not empty.'
+          PR_CONTAINS_PATTERN: '.{20,}'
+          PR_NOT_CONTAINS_PATTERN: '.*Why is this PR necessary?.*'
+#          PR_COMMENT: 'Please check description. \nShould be meaningful and not empty.'
 
       - name: Unit tests
         run: ./tests/test.sh

--- a/.github/workflows/pr-self-checker.yml
+++ b/.github/workflows/pr-self-checker.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   self-check:
 
-    name: Check description
+    name: Run tests
     runs-on: [ubuntu-latest]
     steps:
       - name: Run actions/checkout

--- a/README.md
+++ b/README.md
@@ -3,13 +3,13 @@ Github Action to check PR description is valid.
 
 Validation strings are regular expressions. Don't forget to escape special chars.
 
-## Usage example:
+## Quick start:
 ```yml
       - name: Run check
-        uses: transferwise/actions-pr-checker@v1.0.0
+        uses: transferwise/actions-pr-checker@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_NOT_CONTAINS_PATTERN: '.*Why is this PR necessary?.*'
+          PR_NOT_CONTAINS_PATTERN: 'Why is this PR necessary?'
           PR_COMMENT: 'Please check description. \nShould be meaningful and not empty.'
 ```
 
@@ -25,3 +25,10 @@ Validation strings are regular expressions. Don't forget to escape special chars
 |SUCCESS_EMOJI | Reaction to PR if check success. Possible: `+1` `-1` `laugh` `confused` `heart` `hooray` `rocket` `eyes` (ref: https://developer.github.com/v3/reactions/#reaction-types) | `heart` |  |
 |FAIL_CLOSES_PR | Close PR in case of check fails | false | |
 |FAIL_EXITS | Fail the check if validation not passing | true | |
+
+
+## More examples
+PR title complies with convention
+```yml
+
+```

--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ Validation strings are regular expressions. Don't forget to escape special chars
 |PR_TITLE_CONTAINS_PATTERN | regexp to validate PR title | `.*` | no
 |PR_TITLE_NOT_CONTAINS_PATTERN | regexp to validate PR title | `pseudo-long-string-constant` | | 
 |PR_COMMENT | Comment to add, if validation not passing| `Please check description. \nShould be meaningful and not empty.` | |
-|SUCCESS_EMOJI | Reaction to PR if check success. Possible: `+1` `-1` `laugh` `confused` `heart` `hooray` `rocket` `eyes` (ref: https://developer.github.com/v3/reactions/#reaction-types) | `heart` |  |
+|SUCCESS_EMOJI | Reaction to PR if check success. Possible: `+1` `-1` `laugh` `confused` `heart` `hooray` `rocket` `eyes` (ref: https://developer.github.com/v3/reactions/#reaction-types) | `+1` |  |
+|SUCCESS_APPROVES_PR | Approve PR when check pass | true | |
 |FAIL_CLOSES_PR | Close PR in case of check fails | false | |
 |FAIL_EXITS | Fail the check if validation not passing | true | |
 

--- a/README.md
+++ b/README.md
@@ -17,19 +17,24 @@ Validation strings are regular expressions. Don't forget to escape special chars
 | Name | Description | Default | Required |
 |------|-------------|---------|:--------:|
 |GITHUB_TOKEN | github bot token | | yes |
-|PR_CONTAINS_PATTERN | regexp to validate PR body | `.*` | no
-|PR_NOT_CONTAINS_PATTERN | regexp to validate PR body | `pseudo-long-string-constant` | |
-|PR_TITLE_CONTAINS_PATTERN | regexp to validate PR title | `.*` | no
-|PR_TITLE_NOT_CONTAINS_PATTERN | regexp to validate PR title | `pseudo-long-string-constant` | | 
+|PR_CONTAINS_PATTERN | Regexp to validate PR body | `.*` | no
+|PR_NOT_CONTAINS_PATTERN | Regexp to validate PR body | `pseudo-long-string-constant` | |
+|PR_TITLE_CONTAINS_PATTERN | Regexp to validate PR title | `.*` | no
+|PR_TITLE_NOT_CONTAINS_PATTERN | Regexp to validate PR title | `pseudo-long-string-constant` | | 
 |PR_COMMENT | Comment to add, if validation not passing| `Please check description. \nShould be meaningful and not empty.` | |
 |SUCCESS_EMOJI | Reaction to PR if check success. Possible: `+1` `-1` `laugh` `confused` `heart` `hooray` `rocket` `eyes` (ref: https://developer.github.com/v3/reactions/#reaction-types) | `+1` |  |
-|SUCCESS_APPROVES_PR | Approve PR when check pass | true | |
+|SUCCESS_APPROVES_PR | Approve PR when check pass. If set to `false` won't request changes, but add comments instead | true | |
 |FAIL_CLOSES_PR | Close PR in case of check fails | false | |
-|FAIL_EXITS | Fail the check if validation not passing | true | |
+|FAIL_EXITS | Fail the check if validation not passing. Use `false` if you want comment, but mark as check as success | true | |
 
 
 ## More examples
 PR title complies with convention
 ```yml
-
+      - name: Check PR title
+        uses: transferwise/actions-pr-checker@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_TITLE_CONTAINS_PATTERN=".*(\\w{3})-([0-9]+).+[^.]$"
+          PR_COMMENT: 'Please check PR title. \nShould follow https://namingconvention.org/git/pull-request-naming.html.'
 ```

--- a/README.md
+++ b/README.md
@@ -9,17 +9,19 @@ Validation strings are regular expressions. Don't forget to escape special chars
         uses: transferwise/actions-pr-checker@v1.0.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PULL_REQUEST_NOT_CONTAINS_PATTERN: '.*Why is this PR necessary?.*'
-          PULL_REQUEST_COMMENT: 'Please check description. \nShould be meaningful and not empty.'
+          PR_NOT_CONTAINS_PATTERN: '.*Why is this PR necessary?.*'
+          PR_COMMENT: 'Please check description. \nShould be meaningful and not empty.'
 ```
 
 ## Parameters
 | Name | Description | Default | Required |
 |------|-------------|---------|:--------:|
 |GITHUB_TOKEN | github bot token | | yes |
-|PULL_REQUEST_CONTAINS_PATTERN | regexp to validate PR body | `.*` | no
-|PULL_REQUEST_NOT_CONTAINS_PATTERN | regexp to validate PR body | `pseudo-long-string-constant` | | 
-|PULL_REQUEST_COMMENT | Comment to add, if validation not passing| `Please check description. \nShould be meaningful and not empty.` | |
+|PR_CONTAINS_PATTERN | regexp to validate PR body | `.*` | no
+|PR_NOT_CONTAINS_PATTERN | regexp to validate PR body | `pseudo-long-string-constant` | |
+|PR_TITLE_CONTAINS_PATTERN | regexp to validate PR title | `.*` | no
+|PR_TITLE_NOT_CONTAINS_PATTERN | regexp to validate PR title | `pseudo-long-string-constant` | | 
+|PR_COMMENT | Comment to add, if validation not passing| `Please check description. \nShould be meaningful and not empty.` | |
 |SUCCESS_EMOJI | Reaction to PR if check success. Possible: `+1` `-1` `laugh` `confused` `heart` `hooray` `rocket` `eyes` (ref: https://developer.github.com/v3/reactions/#reaction-types) | `heart` |  |
 |FAIL_CLOSES_PR | Close PR in case of check fails | false | |
 |FAIL_EXITS | Fail the check if validation not passing | true | |

--- a/comparison.sh
+++ b/comparison.sh
@@ -38,5 +38,5 @@ title_comparison() {
 
 tags_comparison() {
   #TODO
-  true
+  return 0
 }

--- a/comparison.sh
+++ b/comparison.sh
@@ -2,21 +2,41 @@
 
 shopt -s nocasematch
 
-pr_comparison() {
-  if [[ "$GITHUB_PULL_REQUEST_EVENT_BODY" =~ $PULL_REQUEST_CONTAINS_PATTERN && ! "$GITHUB_PULL_REQUEST_EVENT_BODY" =~ $PULL_REQUEST_NOT_CONTAINS_PATTERN ]]; then
-    BODY_IS_OK=true
-  else
-    BODY_IS_OK=false
-  fi
-
-  if $BODY_IS_OK
+body_comparison() {
+  if [[ ! "$GITHUB_PULL_REQUEST_EVENT_BODY" =~ $PR_CONTAINS_PATTERN ]]
   then
-    echo "PR BODY matches"
-
-    return
-  else
-    echo "PR BODY not matches"
-
-    false
+    echo "PR body does not match pattern \"${PR_CONTAINS_PATTERN}\""
+    return 1
   fi
+
+  if [[ "$GITHUB_PULL_REQUEST_EVENT_BODY" =~ $PR_NOT_CONTAINS_PATTERN ]]
+  then
+    echo "PR body should not contain pattern \"${PR_NOT_CONTAINS_PATTERN}\""
+    return 1
+  fi
+
+  return 0
+}
+
+
+title_comparison() {
+  if [[ ! "$GITHUB_PULL_REQUEST_EVENT_TITLE" =~ $PR_TITLE_CONTAINS_PATTERN ]]
+  then
+    echo "PR title \"${GITHUB_PULL_REQUEST_EVENT_TITLE}\" does not match pattern \"${PR_TITLE_CONTAINS_PATTERN}\""
+    return 1
+  fi
+
+  if [[ "$GITHUB_PULL_REQUEST_EVENT_TITLE" =~ $PR_TITLE_NOT_CONTAINS_PATTERN ]]
+  then
+    echo "PR title \"${GITHUB_PULL_REQUEST_EVENT_TITLE}\" should not contain pattern \"${PR_TITLE_NOT_CONTAINS_PATTERN}\""
+    return 1
+  fi
+
+  return 0
+}
+
+
+tags_comparison() {
+  #TODO
+  true
 }

--- a/comparison.sh
+++ b/comparison.sh
@@ -5,13 +5,13 @@ shopt -s nocasematch
 body_comparison() {
   if [[ ! "$GITHUB_PULL_REQUEST_EVENT_BODY" =~ $PR_CONTAINS_PATTERN ]]
   then
-    echo "PR body does not match pattern \"${PR_CONTAINS_PATTERN}\""
+    echo "PR description does not match pattern \"${PR_CONTAINS_PATTERN}\""
     return 1
   fi
 
   if [[ "$GITHUB_PULL_REQUEST_EVENT_BODY" =~ $PR_NOT_CONTAINS_PATTERN ]]
   then
-    echo "PR body should not contain pattern \"${PR_NOT_CONTAINS_PATTERN}\""
+    echo "PR description should not contain pattern \"${PR_NOT_CONTAINS_PATTERN}\""
     return 1
   fi
 

--- a/defaults.sh
+++ b/defaults.sh
@@ -60,7 +60,7 @@ if [[ -z "$PR_COMMENT" ]]; then
 fi
 
 if [[ -z "$SUCCESS_EMOJI" ]]; then
-  SUCCESS_EMOJI=heart
+  SUCCESS_EMOJI="+1"
 fi
 
 if [[ -z "$FAIL_CLOSES_PR" ]]; then
@@ -69,4 +69,8 @@ fi
 
 if [[ -z "$FAIL_EXITS" ]]; then
   FAIL_EXITS=true
+fi
+
+if [[ -z "$SUCCESS_APPROVES_PR" ]]; then
+  SUCCESS_APPROVES_PR=true
 fi

--- a/defaults.sh
+++ b/defaults.sh
@@ -25,8 +25,8 @@ fi
 #  exit 1
 #fi
 
-#if [[ ! -z "$PULL_REQUEST_PATTERN" && -z "$PULL_REQUEST_COMMENT" ]]; then
-#  echo "Set the PULL_REQUEST_COMMENT env variable."
+#if [[ ! -z "$PULL_REQUEST_PATTERN" && -z "$PR_COMMENT" ]]; then
+#  echo "Set the PR_COMMENT env variable."
 #  exit 1
 #fi
 #
@@ -35,20 +35,28 @@ fi
 #  exit 1
 #fi
 
-if [[ -z "$PULL_REQUEST_CONTAINS_PATTERN" ]]; then
-  PULL_REQUEST_CONTAINS_PATTERN=$PULL_REQUEST_PATTERN
+if [[ -z "$PR_CONTAINS_PATTERN" ]]; then
+  PR_CONTAINS_PATTERN=$PULL_REQUEST_PATTERN
 fi
 
-if [[ -z "$PULL_REQUEST_CONTAINS_PATTERN" ]]; then
-  PULL_REQUEST_CONTAINS_PATTERN=".*"
+if [[ -z "$PR_CONTAINS_PATTERN" ]]; then
+  PR_CONTAINS_PATTERN=".*"
 fi
 
-if [[ -z "$PULL_REQUEST_NOT_CONTAINS_PATTERN" ]]; then
-  PULL_REQUEST_NOT_CONTAINS_PATTERN="pseudo-long-string-constant"
+if [[ -z "$PR_NOT_CONTAINS_PATTERN" ]]; then
+  PR_NOT_CONTAINS_PATTERN="pseudo-long-string-constant"
 fi
 
-if [[ -z "$PULL_REQUEST_COMMENT" ]]; then
-  PULL_REQUEST_COMMENT="Please check description. \nShould be meaningful and not empty."
+if [[ -z "$PR_TITLE_CONTAINS_PATTERN" ]]; then
+  PR_TITLE_CONTAINS_PATTERN=".*"
+fi
+
+if [[ -z "$PR_TITLE_NOT_CONTAINS_PATTERN" ]]; then
+  PR_TITLE_NOT_CONTAINS_PATTERN="pseudo-long-string-constant"
+fi
+
+if [[ -z "$PR_COMMENT" ]]; then
+  PR_COMMENT="Please check description. \nShould be meaningful and not empty."
 fi
 
 if [[ -z "$SUCCESS_EMOJI" ]]; then

--- a/functions.sh
+++ b/functions.sh
@@ -59,6 +59,23 @@ sendComment() {
 }
 
 
+# Comment reuesting changes to PR
+# @param - GITHUB_PULL_REQUEST_EVENT_NUMBER
+# @param - comment text
+requestChangesComment() {
+    local GITHUB_ISSUE_NUMBER="$1"
+    local GITHUB_ISSUE_COMMENT="$2"
+
+    curl -sSL \
+         -H "Authorization: token ${GITHUB_TOKEN}" \
+         -H "Accept: application/vnd.github.v3+json" \
+         -X POST \
+         -H "Content-Type: application/json" \
+         -d "{\"body\":\"${GITHUB_ISSUE_COMMENT}\", \"event\":\"REQUEST_CHANGES\"}" \
+            "https://api.github.com/repos/${GITHUB_REPOSITORY}/pulls/${GITHUB_ISSUE_NUMBER}/reviews"
+}
+
+
 # Close PR
 # @param - GITHUB_PULL_REQUEST_EVENT_NUMBER
 closeIssue() {

--- a/functions.sh
+++ b/functions.sh
@@ -75,7 +75,7 @@ requestChangesComment() {
         )
     LAST_STATE=$(echo "${LIST}" | jq -r "last( .[] | select (.user.login | contains(\"github-actions[bot]\")) | .state )")
     echo $LAST_STATE
-    if [[ $LAST_STATE -eq "CHANGES_REQUESTED" ]]; then
+    if [[ $LAST_STATE == "CHANGES_REQUESTED" ]]; then
       return 0
     fi
 

--- a/functions.sh
+++ b/functions.sh
@@ -74,12 +74,10 @@ requestChangesComment() {
             "https://api.github.com/repos/${GITHUB_REPOSITORY}/pulls/${GITHUB_ISSUE_NUMBER}/reviews" \
         )
     LAST_STATE=$(echo "${LIST}" | jq -r "last( .[] | select (.user.login | contains(\"github-actions[bot]\")) | .state )")
-    echo $LAST_STATE
     if [[ $LAST_STATE == "CHANGES_REQUESTED" ]]; then
       return 0
     fi
 
-    echo "ask for changes"
     curl -sSL \
          -H "Authorization: token ${GITHUB_TOKEN}" \
          -H "Accept: application/vnd.github.v3+json" \
@@ -94,6 +92,18 @@ requestChangesComment() {
 # @param - GITHUB_PULL_REQUEST_EVENT_NUMBER
 approvePr() {
     local GITHUB_ISSUE_NUMBER="$1"
+
+    LIST=$(curl -sSL \
+         -H "Authorization: token ${GITHUB_TOKEN}" \
+         -H "Accept: application/vnd.github.v3+json" \
+         -X GET \
+         -H "Content-Type: application/json" \
+            "https://api.github.com/repos/${GITHUB_REPOSITORY}/pulls/${GITHUB_ISSUE_NUMBER}/reviews" \
+        )
+    LAST_STATE=$(echo "${LIST}" | jq -r "last( .[] | select (.user.login | contains(\"github-actions[bot]\")) | .state )")
+    if [[ $LAST_STATE == "APPROVED" ]]; then
+      return 0
+    fi
 
     curl -sSL \
          -H "Authorization: token ${GITHUB_TOKEN}" \

--- a/functions.sh
+++ b/functions.sh
@@ -74,10 +74,12 @@ requestChangesComment() {
             "https://api.github.com/repos/${GITHUB_REPOSITORY}/pulls/${GITHUB_ISSUE_NUMBER}/reviews" \
         )
     LAST_STATE=$(echo "${LIST}" | jq -r "last( .[] | select (.user.login | contains(\"github-actions[bot]\")) | .state )")
+    echo $LAST_STATE
     if [[ $LAST_STATE -eq "CHANGES_REQUESTED" ]]; then
-      return
+      return 0
     fi
 
+    echo "ask for changes"
     curl -sSL \
          -H "Authorization: token ${GITHUB_TOKEN}" \
          -H "Accept: application/vnd.github.v3+json" \

--- a/functions.sh
+++ b/functions.sh
@@ -59,7 +59,7 @@ sendComment() {
 }
 
 
-# Comment reuesting changes to PR
+# Comment requesting changes to PR
 # @param - GITHUB_PULL_REQUEST_EVENT_NUMBER
 # @param - comment text
 requestChangesComment() {
@@ -72,6 +72,45 @@ requestChangesComment() {
          -X POST \
          -H "Content-Type: application/json" \
          -d "{\"body\":\"${GITHUB_ISSUE_COMMENT}\", \"event\":\"REQUEST_CHANGES\"}" \
+            "https://api.github.com/repos/${GITHUB_REPOSITORY}/pulls/${GITHUB_ISSUE_NUMBER}/reviews"
+}
+
+
+# Remove comment with requested changes
+# @param - GITHUB_PULL_REQUEST_EVENT_NUMBER
+# @param - comment text
+removeRequestChanges() {
+    local GITHUB_ISSUE_NUMBER="$1"
+    local GITHUB_ISSUE_COMMENT="$2"
+
+    LIST=$(curl -sSL \
+         -H "Authorization: token ${GITHUB_TOKEN}" \
+         -H "Accept: application/vnd.github.v3+json" \
+         -X GET \
+         -H "Content-Type: application/json" \
+            "https://api.github.com/repos/${GITHUB_REPOSITORY}/pulls/${GITHUB_ISSUE_NUMBER}/reviews" \
+        )
+    REVIEW_ID=$(echo "${LIST}" | jq ".[] | select (.body | contains(\"${GITHUB_ISSUE_COMMENT}\")) | .id")
+    curl -sSL \
+         -H "Authorization: token ${GITHUB_TOKEN}" \
+         -H "application/vnd.github.v3+json" \
+         -X DELETE \
+         -H "Content-Type: application/json" \
+            "https://api.github.com/repos/${GITHUB_REPOSITORY}/pulls/${GITHUB_ISSUE_NUMBER}/reviews/${REVIEW_ID}"
+}
+
+
+# Approve PR
+# @param - GITHUB_PULL_REQUEST_EVENT_NUMBER
+approvePr() {
+    local GITHUB_ISSUE_NUMBER="$1"
+
+    curl -sSL \
+         -H "Authorization: token ${GITHUB_TOKEN}" \
+         -H "Accept: application/vnd.github.v3+json" \
+         -X POST \
+         -H "Content-Type: application/json" \
+         -d "{\"event\":\"APPROVE\"}" \
             "https://api.github.com/repos/${GITHUB_REPOSITORY}/pulls/${GITHUB_ISSUE_NUMBER}/reviews"
 }
 

--- a/pr-checker.sh
+++ b/pr-checker.sh
@@ -33,20 +33,23 @@ main() {
 
         echo "GITHUB_PULL_REQUEST_EVENT_TITLE:"
         echo "$GITHUB_PULL_REQUEST_EVENT_TITLE"
-        echo "GITHUB_PULL_REQUEST_EVENT_BODY:"
-        echo "$GITHUB_PULL_REQUEST_EVENT_BODY"
         echo "GITHUB_PULL_REQUEST_EVENT_LABELS:"
         echo "$GITHUB_PULL_REQUEST_EVENT_LABELS"
+        echo "GITHUB_PULL_REQUEST_EVENT_BODY:"
+        echo "$GITHUB_PULL_REQUEST_EVENT_BODY"
 
         body_comparison && title_comparison && tags_comparison
         if [[ $? -eq 0 ]]
           then
             sendReaction "$GITHUB_PULL_REQUEST_EVENT_NUMBER" "$SUCCESS_EMOJI"
             echo "reaction sent"
+
+            removeRequestChanges "$GITHUB_PULL_REQUEST_EVENT_NUMBER" "$PR_COMMENT"
+            echo "request changes removed"
+
+            approvePr "$GITHUB_PULL_REQUEST_EVENT_NUMBER"
           else
 
-            sendComment "$GITHUB_PULL_REQUEST_EVENT_NUMBER" "$PR_COMMENT"
-            echo "sent comment"
             requestChangesComment "$GITHUB_PULL_REQUEST_EVENT_NUMBER" "$PR_COMMENT"
             echo "requested changes"
 

--- a/pr-checker.sh
+++ b/pr-checker.sh
@@ -22,23 +22,33 @@ main() {
 
     # handle pull_request
     if [[ "$GITHUB_EVENT_NAME" == "pull_request" ]]; then  # && "$GITHUB_EVENT_ACTION" == "opened"
+        export GITHUB_PULL_REQUEST_EVENT_TITLE=$(jq --raw-output .pull_request.title "$GITHUB_EVENT_PATH")
         export GITHUB_PULL_REQUEST_EVENT_BODY=$(jq --raw-output .pull_request.body "$GITHUB_EVENT_PATH")
+        export GITHUB_PULL_REQUEST_EVENT_LABELS=$(jq --raw-output .pull_request.labels "$GITHUB_EVENT_PATH")
         GITHUB_PULL_REQUEST_EVENT_NUMBER=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")
 
         echo "GITHUB_PULL_REQUEST_EVENT_NUMBER: ${GITHUB_PULL_REQUEST_EVENT_NUMBER}"
-        echo "PULL_REQUEST_CONTAINS_PATTERN: ${PULL_REQUEST_CONTAINS_PATTERN}"
-        echo "PULL_REQUEST_NOT_CONTAINS_PATTERN: ${PULL_REQUEST_NOT_CONTAINS_PATTERN}"
+        echo "PR_CONTAINS_PATTERN: ${PR_CONTAINS_PATTERN}"
+        echo "PR_NOT_CONTAINS_PATTERN: ${PR_NOT_CONTAINS_PATTERN}"
+
+        echo "GITHUB_PULL_REQUEST_EVENT_TITLE:"
+        echo "$GITHUB_PULL_REQUEST_EVENT_TITLE"
         echo "GITHUB_PULL_REQUEST_EVENT_BODY:"
         echo "$GITHUB_PULL_REQUEST_EVENT_BODY"
+        echo "GITHUB_PULL_REQUEST_EVENT_LABELS:"
+        echo "$GITHUB_PULL_REQUEST_EVENT_LABELS"
 
-        pr_comparison
+        #pr_comparison
+        body_comparison && title_comparison && tags_comparison
         if [[ $? ]]
           then
             sendReaction "$GITHUB_PULL_REQUEST_EVENT_NUMBER" "$SUCCESS_EMOJI"
             echo "reaction sent"
           else
-            sendComment "$GITHUB_PULL_REQUEST_EVENT_NUMBER" "$PULL_REQUEST_COMMENT"
+            sendComment "$GITHUB_PULL_REQUEST_EVENT_NUMBER" "$PR_COMMENT"
             echo "sent comment"
+            requestChangesComment "$GITHUB_PULL_REQUEST_EVENT_NUMBER" "$PR_COMMENT"
+            echo "requested changes"
 
             removeReaction "$GITHUB_PULL_REQUEST_EVENT_NUMBER" "$SUCCESS_EMOJI"
             echo "reaction removed"

--- a/pr-checker.sh
+++ b/pr-checker.sh
@@ -38,9 +38,8 @@ main() {
         echo "GITHUB_PULL_REQUEST_EVENT_LABELS:"
         echo "$GITHUB_PULL_REQUEST_EVENT_LABELS"
 
-        #pr_comparison
         body_comparison && title_comparison && tags_comparison
-        if [[ $? ]]
+        if [[ $? -eq 0 ]]
           then
             sendReaction "$GITHUB_PULL_REQUEST_EVENT_NUMBER" "$SUCCESS_EMOJI"
             echo "reaction sent"

--- a/pr-checker.sh
+++ b/pr-checker.sh
@@ -44,9 +44,6 @@ main() {
             sendReaction "$GITHUB_PULL_REQUEST_EVENT_NUMBER" "$SUCCESS_EMOJI"
             echo "reaction sent"
 
-            removeRequestChanges "$GITHUB_PULL_REQUEST_EVENT_NUMBER" "$PR_COMMENT"
-            echo "request changes removed"
-
             approvePr "$GITHUB_PULL_REQUEST_EVENT_NUMBER"
           else
 

--- a/pr-checker.sh
+++ b/pr-checker.sh
@@ -44,11 +44,19 @@ main() {
             sendReaction "$GITHUB_PULL_REQUEST_EVENT_NUMBER" "$SUCCESS_EMOJI"
             echo "reaction sent"
 
-            approvePr "$GITHUB_PULL_REQUEST_EVENT_NUMBER"
+            if [[ "$SUCCESS_APPROVES_PR" == true ]]; then
+              approvePr "$GITHUB_PULL_REQUEST_EVENT_NUMBER"
+              echo "pr approved"
+            fi
           else
 
-            requestChangesComment "$GITHUB_PULL_REQUEST_EVENT_NUMBER" "$PR_COMMENT"
-            echo "requested changes"
+            if [[ "$SUCCESS_APPROVES_PR" == true ]]; then
+              requestChangesComment "$GITHUB_PULL_REQUEST_EVENT_NUMBER" "$PR_COMMENT"
+              echo "requested changes"
+            else
+              sendComment "$GITHUB_PULL_REQUEST_EVENT_NUMBER" "$PR_COMMENT"
+              echo "sent comment"
+            fi
 
             removeReaction "$GITHUB_PULL_REQUEST_EVENT_NUMBER" "$SUCCESS_EMOJI"
             echo "reaction removed"

--- a/pr-checker.sh
+++ b/pr-checker.sh
@@ -45,6 +45,7 @@ main() {
             sendReaction "$GITHUB_PULL_REQUEST_EVENT_NUMBER" "$SUCCESS_EMOJI"
             echo "reaction sent"
           else
+
             sendComment "$GITHUB_PULL_REQUEST_EVENT_NUMBER" "$PR_COMMENT"
             echo "sent comment"
             requestChangesComment "$GITHUB_PULL_REQUEST_EVENT_NUMBER" "$PR_COMMENT"

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -13,58 +13,141 @@ source "${DIR}/../comparison.sh"
 source "${DIR}/assert.sh"
 
 
+# TESTS PR BODY
+
 echo $((i+=1))
 echo "Nothing set - OK"
 GITHUB_PULL_REQUEST_EVENT_BODY=""
-pr_comparison
+body_comparison
 assert_eq 0 $? "$ERR"
 
 echo $((i+=1))
 echo "Nothing set, body not empty - OK"
 GITHUB_PULL_REQUEST_EVENT_BODY="Something"
-pr_comparison
+body_comparison
 assert_eq 0 $? "$ERR"
 
 echo $((i+=1))
 echo "Body not matches pattern - FAIL"
 GITHUB_PULL_REQUEST_EVENT_BODY="Hello"
-PULL_REQUEST_CONTAINS_PATTERN=".{20,}"
-pr_comparison
+PR_CONTAINS_PATTERN=".{20,}"
+body_comparison
 assert_eq 1 $? "$ERR"
 
 echo $((i+=1))
 echo "Body matches pattern - OK"
 GITHUB_PULL_REQUEST_EVENT_BODY="Hello, fixing [TICKET] and [OTHER]"
-PULL_REQUEST_CONTAINS_PATTERN="\[TICKET\]"
-pr_comparison
+PR_CONTAINS_PATTERN="\[TICKET\]"
+body_comparison
 assert_eq 0 $? "$ERR"
 
 echo $((i+=1))
 echo "Body matches pattern case insensitive - OK"
 GITHUB_PULL_REQUEST_EVENT_BODY="Fixing [Ticket]"
-PULL_REQUEST_CONTAINS_PATTERN="\[TICKET\]"
-pr_comparison
+PR_CONTAINS_PATTERN="\[TICKET\]"
+body_comparison
 assert_eq 0 $? "$ERR"
 
 echo $((i+=1))
 echo "Body matches pattern and NOT pattern - OK"
 GITHUB_PULL_REQUEST_EVENT_BODY="Hello, fixing [TICKET] and [OTHER]"
-PULL_REQUEST_CONTAINS_PATTERN="\[TICKET\]"
-PULL_REQUEST_NOT_CONTAINS_PATTERN=".*Why is this PR necessary?.*"
-pr_comparison
+PR_CONTAINS_PATTERN="\[TICKET\]"
+PR_NOT_CONTAINS_PATTERN=".*Why is this PR necessary?.*"
+body_comparison
 assert_eq 0 $? "$ERR"
 
 echo $((i+=1))
 echo "Body not matches pattern and matches NOT pattern - FAIL"
 GITHUB_PULL_REQUEST_EVENT_BODY="This is default text.\n Why is this PR necessary?\nAdd text."
-PULL_REQUEST_CONTAINS_PATTERN="\[TICKET\]"
-PULL_REQUEST_NOT_CONTAINS_PATTERN=".*Why is this PR necessary?.*"
-pr_comparison
+PR_CONTAINS_PATTERN="\[TICKET\]"
+PR_NOT_CONTAINS_PATTERN=".*Why is this PR necessary?.*"
+body_comparison
 assert_eq 1 $? "$ERR"
 
 echo $((i+=1))
 echo "Body not matches NOT pattern - OK"
 GITHUB_PULL_REQUEST_EVENT_BODY="Hello, fixing [TICKET] and [OTHER]"
-PULL_REQUEST_NOT_CONTAINS_PATTERN=".*Why is this PR necessary?.*"
-pr_comparison
+PR_NOT_CONTAINS_PATTERN=".*Why is this PR necessary?.*"
+body_comparison
 assert_eq 0 $? "$ERR"
+
+
+# TEST PR TITLE
+source "${DIR}/../defaults.sh"
+
+echo $((i+=1))
+echo "Nothing set - OK"
+GITHUB_PULL_REQUEST_EVENT_TITLE=""
+title_comparison
+assert_eq 0 $? "$ERR"
+
+echo $((i+=1))
+echo "Nothing set, title not empty - OK"
+GITHUB_PULL_REQUEST_EVENT_TITLE="Something"
+title_comparison
+assert_eq 0 $? "$ERR"
+
+echo $((i+=1))
+echo "Pattern set, title matches pattern - OK"
+GITHUB_PULL_REQUEST_EVENT_TITLE="CLS-23 Add Edit on Github button to all the pages"
+PR_TITLE_CONTAINS_PATTERN=".*(\\w{3})-([0-9]+).+[^.]$"
+title_comparison
+assert_eq 0 $? "$ERR"
+
+echo $((i+=1))
+echo "Pattern set, title not matches pattern - FAIL"
+GITHUB_PULL_REQUEST_EVENT_TITLE="Add Edit on Github button to all the pages."
+PR_TITLE_CONTAINS_PATTERN=".*(\\w{3})-([0-9]+).+[^.]$"
+title_comparison
+assert_eq 1 $? "$ERR"
+
+echo $((i+=1))
+echo "Title not matches NOT pattern - FAIL"
+GITHUB_PULL_REQUEST_EVENT_TITLE="Add Edit on Github button to all the pages."
+PR_TITLE_CONTAINS_PATTERN=".*"
+PR_TITLE_NOT_CONTAINS_PATTERN="Github"
+title_comparison
+assert_eq 1 $? "$ERR"
+
+echo $((i+=1))
+echo "Title not matches both patterns - FAIL"
+GITHUB_PULL_REQUEST_EVENT_TITLE="Oranges for christmas"
+PR_TITLE_CONTAINS_PATTERN="apples"
+PR_TITLE_NOT_CONTAINS_PATTERN="oranges"
+title_comparison
+assert_eq 1 $? "$ERR"
+
+
+# TEST BODY AND TITLE CHECKS
+echo $((i+=1))
+echo "Body ok, title ok - OK"
+GITHUB_PULL_REQUEST_EVENT_BODY="Hello, fixing [TICKET] and [OTHER]"
+PR_CONTAINS_PATTERN="ticket"
+PR_NOT_CONTAINS_PATTERN="oranges"
+GITHUB_PULL_REQUEST_EVENT_TITLE="Add Edit on Github button."
+PR_TITLE_CONTAINS_PATTERN="github"
+PR_TITLE_NOT_CONTAINS_PATTERN="oranges"
+body_comparison && title_comparison
+assert_eq 0 $? "$ERR"
+
+echo $((i+=1))
+echo "Body ok, title fail - FAIL"
+GITHUB_PULL_REQUEST_EVENT_BODY="Hello, fixing [TICKET] and [OTHER]"
+PR_CONTAINS_PATTERN="ticket"
+PR_NOT_CONTAINS_PATTERN="oranges"
+GITHUB_PULL_REQUEST_EVENT_TITLE="Add Edit on Github button"
+PR_TITLE_CONTAINS_PATTERN="[0-9]{3}"
+PR_TITLE_NOT_CONTAINS_PATTERN="oranges"
+body_comparison && title_comparison
+assert_eq 1 $? "$ERR"
+
+echo $((i+=1))
+echo "Body fail, title ok - FAIL"
+GITHUB_PULL_REQUEST_EVENT_BODY="Hello, fixing [TICKET] and [OTHER]"
+PR_CONTAINS_PATTERN="ticket"
+PR_NOT_CONTAINS_PATTERN="other"
+GITHUB_PULL_REQUEST_EVENT_TITLE="Add Edit on Github button"
+PR_TITLE_CONTAINS_PATTERN="github"
+PR_TITLE_NOT_CONTAINS_PATTERN="oranges"
+body_comparison && title_comparison
+assert_eq 1 $? "$ERR"


### PR DESCRIPTION
## Context

THE existing PR checker build by us can only check the PR body text.

For checking tags an external action is used, created by unknown guy (not officially github), we want to have in-house built alternative.

### Changes

Enhanced validation to check PR titles


## Checklist
- [x] I have considered the impact of this change and added a [Change Classification](
https://transferwise.atlassian.net/wiki/spaces/EKB/pages/1401189673/Change+Classifications+and+Expectations) Label (`change:standard`, `change:impactful`, `change:emergency`)
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
