### PR TITLE
fixing checkout version to pass

### DIFF
--- a/.github/workflows/pr-self-checker.yml
+++ b/.github/workflows/pr-self-checker.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: [ubuntu-latest]
     steps:
       - name: Run actions/checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v4
         with:
           fetch-depth: 1
 


### PR DESCRIPTION
## Context

Updating the deprecated version of the checkout to the actual one. Now this should be able to pass the self-checks

## Checklist
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
