### PR TITLE
Check the result of reactions api in a safer way

### DIFF
--- a/functions.sh
+++ b/functions.sh
@@ -32,13 +32,15 @@ removeReaction() {
          -H "Content-Type: application/json" \
             "https://api.github.com/repos/${GITHUB_REPOSITORY}/issues/${GITHUB_ISSUE_NUMBER}/reactions" \
         )
-    COMMENT_ID=$(echo "${LIST}" | jq ".[] | select (.content | contains(\"${EMOJI}\")) | .id")
+    COMMENT_ID=$(echo "${LIST}" | jq -r --arg emoji "$EMOJI" '.[] | objects | select(.content? == $emoji) | .id' | head -n 1)
+    if [ -n "$COMMENT_ID" ]; then
     curl -sSL \
          -H "Authorization: token ${GITHUB_TOKEN}" \
          -H "Accept: application/vnd.github.squirrel-girl-preview+json" \
          -X DELETE \
          -H "Content-Type: application/json" \
             "https://api.github.com/repos/${GITHUB_REPOSITORY}/issues/${GITHUB_ISSUE_NUMBER}/reactions/${COMMENT_ID}"
+    fi
 }
 
 


### PR DESCRIPTION
## Context

When a PR does not have any reactions in the descriptions, this query fails to retried "content" field and causes the github action check to fail with irrelevant error message.
Yes, it still fails when expected to fail, but the error message is confusing to the engineers. 

So this changes makes the parsing of "COMMENT_ID" safer, allowing for situations where it does not exist and skips deleting the reaction if it does not exist.

<!-- Why is this PR necessary? If available, include links to a JIRA ticket or other relevant documentation. -->

## Checklist
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
